### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP (Model Context Protocol) server that provides Ethereum blockchain data tools via Etherscan's API. Features include checking ETH balances, viewing transaction history, tracking ERC20 transfers, fetching contract ABIs, monitoring gas prices, and resolving ENS names.
 
+<a href="https://glama.ai/mcp/servers/mf5frh1039"><img width="380" height="200" src="https://glama.ai/mcp/servers/mf5frh1039/badge" alt="Etherscan Server MCP server" /></a>
+
 ## Features
 
 - **Balance Checking**: Get ETH balance for any Ethereum address


### PR DESCRIPTION
This PR adds a badge for the [MCP Etherscan Server](https://glama.ai/mcp/servers/mf5frh1039) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/mf5frh1039"><img width="380" height="200" src="https://glama.ai/mcp/servers/mf5frh1039/badge" alt="Etherscan Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.